### PR TITLE
Adding some Georide sensors

### DIFF
--- a/custom_components/georide/binary_sensor.py
+++ b/custom_components/georide/binary_sensor.py
@@ -30,6 +30,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities): # pylint: d
         entities.append(GeoRideCrashedBinarySensorEntity(coordinator, tracker_device))
         entities.append(GeoRideOwnerBinarySensorEntity(coordinator, tracker_device))
         entities.append(GeoRideActiveSubscriptionBinarySensorEntity(coordinator, tracker_device))
+        entities.append(GeoRideNetworkBinarySensorEntity(coordinator, tracker_device))
+        entities.append(GeoRideMovingBinarySensorEntity(coordinator, tracker_device))
 
         hass.data[GEORIDE_DOMAIN]["devices"][tracker_device.tracker.tracker_id] = coordinator
 
@@ -67,6 +69,11 @@ class GeoRideStolenBinarySensorEntity(GeoRideBinarySensorEntity):
     def unique_id(self):
         """Return the unique ID."""
         return f"is_stolen_{self._tracker_device.tracker.tracker_id}"
+    
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return f"problem"
 
     @property
     def is_on(self):
@@ -92,6 +99,11 @@ class GeoRideCrashedBinarySensorEntity(GeoRideBinarySensorEntity):
     def unique_id(self):
         """Return the unique ID."""
         return f"is_crashed_{self._tracker_device.tracker.tracker_id}"
+    
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return f"problem"
 
     @property
     def is_on(self):
@@ -155,3 +167,62 @@ class GeoRideOwnerBinarySensorEntity(GeoRideBinarySensorEntity):
         """ GeoRide odometer name """
         return f"{self._name} is own tracker"
   
+class GeoRideNetworkBinarySensorEntity(GeoRideBinarySensorEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator[Mapping[str, Any]],
+                 tracker_device: Device):
+        """Set up Georide entity."""
+        super().__init__(coordinator, tracker_device)
+        self.entity_id = f"{ENTITY_ID_FORMAT.format('have_network')}.{tracker_device.tracker.tracker_id}"# pylint: disable=C0301
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return f"have_network_{self._tracker_device.tracker.tracker_id}"
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return f"connectivity"
+
+    @property
+    def is_on(self):
+        """state value property"""
+        if self._tracker_device.tracker.status == "online":
+            return True
+        return False
+
+    @property
+    def name(self):
+        """ GeoRide name """
+        return f"{self._name} have network"
+  
+class GeoRideMovingBinarySensorEntity(GeoRideBinarySensorEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator[Mapping[str, Any]],
+                 tracker_device: Device):
+        """Set up Georide entity."""
+        super().__init__(coordinator, tracker_device)
+        self.entity_id = f"{ENTITY_ID_FORMAT.format('moving')}.{tracker_device.tracker.tracker_id}"# pylint: disable=C0301
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return f"moving_{self._tracker_device.tracker.tracker_id}"
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return f"moving"
+
+    @property
+    def is_on(self):
+        """state value property"""
+        return self._tracker_device.tracker.moving
+
+    @property
+    def name(self):
+        """ GeoRide name """
+        return f"{self._name} is moving"

--- a/custom_components/georide/sensor.py
+++ b/custom_components/georide/sensor.py
@@ -46,7 +46,7 @@ class GeoRideOdometerSensorEntity(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._tracker_device = tracker_device
         self._name = tracker_device.tracker.tracker_name
-        self._unit_of_measurement = "m"
+        self._unit_of_measurement = "km"
         self.entity_id = f"{ENTITY_ID_FORMAT.format('odometer')}.{tracker_device.tracker.tracker_id}"# pylint: disable=C0301
 
         self._state = 0
@@ -60,7 +60,8 @@ class GeoRideOdometerSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def state(self):
         """state property"""
-        return self._tracker_device.tracker.odometer
+        odometer = self._tracker_device.tracker.odometer //1000
+        return odometer
 
     @property
     def unit_of_measurement(self):

--- a/custom_components/georide/sensor.py
+++ b/custom_components/georide/sensor.py
@@ -31,6 +31,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities): # pylint: d
         entities.append(GeoRideOdometerSensorEntity(coordinator, tracker_device, hass))
         entities.append(GeoRideInternalBatterySensorEntity(coordinator, tracker_device))
         entities.append(GeoRideExternalBatterySensorEntity(coordinator, tracker_device))
+        entities.append(GeoRideFixtimeSensorEntity(coordinator, tracker_device))
 
     async_add_entities(entities)
 
@@ -118,7 +119,7 @@ class GeoRideInternalBatterySensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def icon(self):
         """icon getter"""
-        return "mdi:counter"
+        return "mdi:battery"
 
     @property
     def device_info(self):
@@ -162,10 +163,48 @@ class GeoRideExternalBatterySensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def icon(self):
         """icon getter"""
-        return "mdi:counter"
+        return "mdi:battery"
 
     @property
     def device_info(self):
         """Return the device info."""
         return self._tracker_device.device_info
     
+class GeoRideFixtimeSensorEntity(CoordinatorEntity, SensorEntity):
+    """Represent a tracked device."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator[Mapping[str, Any]],
+                 tracker_device:Device):
+        """Set up GeoRide entity."""
+        super().__init__(coordinator)
+        self._tracker_device = tracker_device
+        self._name = tracker_device.tracker.tracker_name
+        self.entity_id = f"{ENTITY_ID_FORMAT.format('fixtime')}.{tracker_device.tracker.tracker_id}"# pylint: disable=C0301
+
+        self._state = 0
+        self._device_class = "timestamp"
+
+    @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return f"fixtime_{self._tracker_device.tracker.tracker_id}"
+
+    @property
+    def state(self):
+        """state property"""
+        return self._tracker_device.tracker.fixtime
+
+    @property
+    def name(self):
+        """ GeoRide fixtime name """
+        return f"{self._name} last fixed position"
+    
+    @property
+    def icon(self):
+        """icon getter"""
+        return "mdi:map-clock"
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        return self._tracker_device.device_info


### PR DESCRIPTION
Hi,

Here are some new sensors for georide (3):

Sensors:
- Changed odomoter to km instead of meters. There was no reason to keep it in meters from my point of view, but that's debatable
- Internal battery (of georide 3)
- External battery (of the bike)
- Fixtime (last registered positition of the georide)

Binary sensors:
- Network status (connected / disconnected)
- Moving status (if there's a moving motion)

There's also an issue with the "active subscription" binary sensor, but it is an issue with georideapilib.
